### PR TITLE
ci: run lint-staged in pre-commit hook and update formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npx lint-staged
 npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-npx lint-staged
+npm run lint-staged
 npm test

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,10 +5,13 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",
-    ["@semantic-release/git", {
-      "assets": ["package.json", "CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ snippets. It allows users to:
 
 ## Commit Guidelines
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) for standardized commit messages, which enable automated versioning via semantic-release. The format is:
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for standardized commit messages, which
+enable automated versioning via semantic-release. The format is:
 
 ```
 <type>(<optional scope>): <description>
@@ -38,6 +39,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) f
 ```
 
 Common types:
+
 - `feat:` - A new feature (triggers MINOR version bump: 1.0.0 → 1.1.0)
 - `fix:` - A bug fix (triggers PATCH version bump: 1.0.0 → 1.0.1)
 - `docs:` - Documentation changes (no version bump)
@@ -48,9 +50,11 @@ Common types:
 - `ci:` - Changes to CI configuration (no version bump)
 
 Breaking changes are indicated with an exclamation mark after the type/scope or with a footer:
+
 - `feat!:` or `BREAKING CHANGE:` in footer - (triggers MAJOR version bump: 1.0.0 → 2.0.0)
 
 To create a commit:
+
 1. Stage your changes with `git add`
 2. Run `npm run commit` (instead of `git commit`)
 3. Follow the interactive prompts to create a proper conventional commit

--- a/README.md
+++ b/README.md
@@ -157,16 +157,20 @@ do the right thing and process the code appropriately.
 
 ### Contributing
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) for standardized commit messages, which enables automated versioning and changelog generation.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) for standardized commit messages, which
+enables automated versioning and changelog generation.
 
 When contributing:
+
 1. Fork the repository and create a feature branch
 2. Make your changes
 3. Run tests with `npm test`
 4. Create commits using `npm run commit` which will guide you through creating a properly formatted commit message
 5. Submit a pull request
 
-The project uses semantic-release for automated versioning and publishing to npm. Version numbers are determined automatically based on commit types:
+The project uses semantic-release for automated versioning and publishing to npm. Version numbers are determined
+automatically based on commit types:
+
 - `feat:` - Minor version bump (1.0.0 → 1.1.0)
 - `fix:` - Patch version bump (1.0.0 → 1.0.1)
 - `feat!:` or `fix!:` or commits with `BREAKING CHANGE:` in the footer - Major version bump (1.0.0 → 2.0.0)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,6 @@
 export default {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    // Optional custom rules can be added here
-  }
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        // Optional custom rules can be added here
+    },
 };

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "vitest": "^3.1.3"
   },
   "lint-staged": {
-    "*.{js,json,md,yml,yaml}": "prettier --write"
+    "**/*.{js,json,md,yml,yaml}": "prettier --write",
+    "**/.*rc.json": "prettier --write",
+    "**/*.config.js": "prettier --write"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prepare": "husky",
     "commit": "npx cz",
     "semantic-release": "semantic-release",
-    "commitlint": "commitlint --edit"
+    "commitlint": "commitlint --edit",
+    "lint-staged": "lint-staged"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",


### PR DESCRIPTION
## Summary
- Add lint-staged to pre-commit hook to format files automatically before commit
- Update lint-staged configuration to handle all file types including config files
- Create npm script for lint-staged and use it in the pre-commit hook
- Format .releaserc.json, CLAUDE.md, commitlint.config.js, and README.md

## Test plan
- Pre-commit hook now runs lint-staged before tests
- Files are automatically formatted when committing changes
- This prevents CI failures due to unformatted files

🤖 Generated with [Claude Code](https://claude.ai/code)