### PR TITLE
MacOS command-click opens CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This is a small plugin for [reveal.js](https://revealjs.com/) that turns C++ `<code>` blocks into presentation-ready
 Compiler-Explorer-linked snippets. It supports:
 
-- Control-click on the code to open [Compiler Explorer](https://compiler-explorer.com)
+- Control-click (Command-click on MacOS) on the code to open [Compiler Explorer](https://compiler-explorer.com)
 - Hiding of regions of the code in the presentation view that appear in the link
 - Setup regions that are collapsed in Compiler Explorer
 - Configuration of the CE instance it links to

--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ export function attachEventListeners(config, element, ceFragment, urlLauncher = 
     // Attach `onclick` to the (presumed `<pre>`) parent element. That way if data-line-numbers is used (which creates
     // multiple code elements), the click event will still work.
     element.parentElement.onclick = evt => {
-        if (evt.ctrlKey) {
+        if (evt.ctrlKey || evt.metaKey) {
             urlLauncher(`${config.baseUrl}#${ceFragment}`);
         }
     };

--- a/tests/attachEventListeners.test.js
+++ b/tests/attachEventListeners.test.js
@@ -47,6 +47,31 @@ describe('attachEventListeners function', () => {
         expect(urlLauncher.getMockImplementation()).toHaveBeenCalledWith('https://godbolt.org#mockFragment');
     });
 
+    it('should navigate to Compiler Explorer URL on Command+Click for MacOS', () => {
+        // Setup mocks
+        const mockConfig = {
+            baseUrl: 'https://godbolt.org',
+        };
+
+        const mockElement = {
+            parentElement: {},
+        };
+
+        const ceFragment = 'mockFragment';
+
+        // Create URL launcher mock
+        const urlLauncher = createURLLauncher();
+
+        // Call the function with our mock URL launcher
+        attachEventListeners(mockConfig, mockElement, ceFragment, urlLauncher.navigate);
+
+        // Trigger Ctrl+Click
+        mockElement.parentElement.onclick({metaKey: true});
+
+        // Verify navigation occurred with correct URL
+        expect(urlLauncher.getMockImplementation()).toHaveBeenCalledWith('https://godbolt.org#mockFragment');
+    });
+
     it('should not navigate on regular click', () => {
         // Setup mocks
         const mockConfig = {


### PR DESCRIPTION
Ctrl-click on MacOS does not work.  Requesting to have command-click open CE links on MacOS (maybe check OS to limit to MacOS?)